### PR TITLE
Parse $GRAFANA_SECURE as an integer

### DIFF
--- a/callback_plugins/grafana_annotations.py
+++ b/callback_plugins/grafana_annotations.py
@@ -76,7 +76,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__()
 
         token = os.getenv('GRAFANA_API_TOKEN')
-        self.secure = os.getenv('GRAFANA_SECURE', 0)
+        self.secure = int(os.getenv('GRAFANA_SECURE', 0))
         if self.secure not in [0, 1]:
             self.secure = 0
         if token is None:


### PR DESCRIPTION
Without the cast, the next if statement would never let secure be set to anything but `0`.